### PR TITLE
Add Vagrant to test current playbook locally

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/stretch64"
+
+  current_hostname = "lobsters.xen.prgmr.com"
+
+  config.vm.define current_hostname do |machine|
+    machine.vm.hostname = current_hostname
+    machine.vm.provision "ansible" do |ansible|
+
+        ansible.groups = {
+            "db" => current_hostname,
+            "mx" => current_hostname,
+            "smtp" => current_hostname,
+            "www" => current_hostname,
+            "www-worker" => current_hostname
+          }
+    
+        ansible.compatibility_mode = "2.0"
+        ansible.playbook = "prod.yml"
+    end
+  end
+
+end


### PR DESCRIPTION
To be able to test the playbook easily, it's nice to have a Vagrant box to run Ansible against.
You can try it by running `vagrant up --provision`, iterate on the playbook, and run `vagrant provision` again.