### PR TITLE
Remove stickers link from about page. Fixes #14

### DIFF
--- a/roles/lobsters/files/app/views/home/about.html.erb
+++ b/roles/lobsters/files/app/views/home/about.html.erb
@@ -239,8 +239,8 @@
   <% end %>
 
   <li><p>
-  <strong><a href="/s/zykwh8/lobsters_stickers">Stickers</a></strong> are
-  available to show your support for the site.
+  <strong>Stickers</strong> are
+  no longer available until an alternative to the Stickermule marketplace is found.
   </p></li>
   </ul>
 


### PR DESCRIPTION
Instead of just removing the link, I think it's better to state that it's no longer available for now.