### PR TITLE
Add systemd's unicorn service

### DIFF
--- a/prod.yml
+++ b/prod.yml
@@ -13,6 +13,13 @@
 #  roles:
 #    - { role: dns }
 
+- name: unicorn
+  tags: unicorn
+  become: yes
+  hosts: www-worker
+  roles:
+    - { role: unicorn }
+
 - name: lobsters
   tags: lobsters
   become: yes
@@ -62,9 +69,3 @@
   roles:
     - { role: tarsnap }
 
-- name: unicorn
-  tags: unicorn
-  become: yes
-  hosts: www-worker
-  roles:
-    - { role: unicorn }

--- a/roles/lobsters/tasks/main.yml
+++ b/roles/lobsters/tasks/main.yml
@@ -92,7 +92,9 @@
 
 - name: restart unicorn
   when: clone.changed or bundler.changed or sitefiles.changed
-  command: pkill -USR2 -f 'unicorn_rails master'
+  systemd: >
+    name="lobsters-unicorn"
+    state=reloaded
 
 - name: cp cron script
   copy: >

--- a/roles/unicorn/files/lobsters-unicorn.service
+++ b/roles/unicorn/files/lobsters-unicorn.service
@@ -13,7 +13,7 @@ Environment=RAILS_ENV=production
 SyslogIdentifier=lobsters-unicorn
 PIDFile=/srv/lobste.rs/run/unicorn.pid
 
-ExecStart=/usr/bin/bundle exec "unicorn_rails -c config/unicorn.rb -E production -D config.ru"
+ExecStart=/usr/bin/bundle exec "unicorn_rails -c config/unicorn.conf.rb -E production -D config.ru"
 ExecStop=/usr/bin/pkill -QUIT -f 'unicorn_rails master'
 ExecReload=/usr/bin/pkill -USR2 -f 'unicorn_rails master'
 

--- a/roles/unicorn/files/lobsters-unicorn.service
+++ b/roles/unicorn/files/lobsters-unicorn.service
@@ -13,9 +13,14 @@ Environment=RAILS_ENV=production
 SyslogIdentifier=lobsters-unicorn
 PIDFile=/srv/lobste.rs/run/unicorn.pid
 
-ExecStart=/usr/bin/bundle exec "unicorn_rails -c config/unicorn.conf.rb -E production -D config.ru"
-ExecStop=/usr/bin/pkill -QUIT -f 'unicorn_rails master'
-ExecReload=/usr/bin/pkill -USR2 -f 'unicorn_rails master'
+Restart=always
+RestartSec=60
+StartLimitBurst=5
+StartLimitInterval=3600
+
+ExecStart=/usr/local/bin/bundle exec "unicorn_rails -c config/unicorn.conf.rb -E production -D config.ru"
+ExecReload=/usr/bin/kill -USR2 $MAINPID
+ExecStop=/usr/bin/kill -QUIT $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/unicorn/files/lobsters-unicorn.service
+++ b/roles/unicorn/files/lobsters-unicorn.service
@@ -1,0 +1,22 @@
+# Unicorn unit file for:
+# Lobste.rs -- https://lobste.rs
+
+[Unit]
+Description=Lobsters Unicorn Server
+#Wants=mariadb.service
+#After=mariadb.service
+
+[Service]
+User=lobsters
+WorkingDirectory=/srv/lobste.rs/http/
+Environment=RAILS_ENV=production
+SyslogIdentifier=lobsters-unicorn
+PIDFile=/srv/lobste.rs/run/unicorn.pid
+
+ExecStart=/usr/bin/bundle exec "unicorn_rails -c config/unicorn.rb -E production -D config.ru"
+ExecStop=/usr/bin/pkill -QUIT -f 'unicorn_rails master'
+ExecReload=/usr/bin/pkill -USR2 -f 'unicorn_rails master'
+
+[Install]
+WantedBy=multi-user.target
+

--- a/roles/unicorn/tasks/main.yml
+++ b/roles/unicorn/tasks/main.yml
@@ -10,3 +10,17 @@
     owner=lobsters
     group=lobsters
     mode="0644"
+
+- name: copy unicorn systemd service config
+  copy: >
+    src="lobsters-unicorn.service"
+    dest="/etc/systemd/system/"
+    owner=lobsters
+    group=lobsters
+    mode="0440"
+
+- name: just force systemd to reread configs
+  systemd: >
+    name="lobsters-unicorn"
+    enabled=yes
+    daemon_reload=yes

--- a/roles/unicorn/tasks/main.yml
+++ b/roles/unicorn/tasks/main.yml
@@ -3,6 +3,15 @@
 - include_tasks: yum.yml
   when: "'{{ family }}' == 'redhat'"
 
+- name: lobsters directory
+  file: >
+    path="/srv/lobste.rs/{{ item }}/"
+    state=directory
+  with_items:
+    - http
+    - run
+    - log
+
 - name: copy up unicorn config
   copy: >
     src="unicorn.conf.rb"


### PR DESCRIPTION
This adds a systemd unit file and uses it to start/reload the app.
It's enabled at startup with the `enabled=yes`.
I didn't specify the restart always because it's not handled to my knowledge now (and that it's usually a bad idea to force restarting blindly a process).

If you have any remark, please do.

Should close #7 