### PR TITLE
Split inventories and group_vars

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-inventory = ./prod.cfg
+inventory = ./inventories/prod.ini
 log_path = ./lobsters-ansible.log
 
 [ssh_connection]

--- a/group_vars/prod.yml
+++ b/group_vars/prod.yml
@@ -1,0 +1,7 @@
+#backup_host: lobsters-backup.xen.prgmr.com
+console_host: lobsters.xen.prgmr.com
+db_host: lobsters.xen.prgmr.com
+#dns_host: 
+mx_host: lobsters.xen.prgmr.com
+smtp_host: lobsters.xen.prgmr.com
+www_host: lobsters.xen.prgmr.com

--- a/inventories/prod.ini
+++ b/inventories/prod.ini
@@ -1,12 +1,3 @@
-[all:vars]
-#backup_host=lobsters-backup.xen.prgmr.com
-console_host=lobsters.xen.prgmr.com
-db_host=lobsters.xen.prgmr.com
-#dns_host=
-mx_host=lobsters.xen.prgmr.com
-smtp_host=lobsters.xen.prgmr.com
-www_host=lobsters.xen.prgmr.com
-
 [backup]
 #lobsters-backup.xen.prgmr.com
 


### PR DESCRIPTION
This is one of the recommended convention from Ansible's documentation.
Setting it up like this will allow adding other inventories (and so environement) in order to add the testing server for the upgrade.

Splitting the variables is also the first step to be able to use them per environement and be able to re-use the variables thorough the playbooks (for example the rails app path will be the same, but not the domain names or things like this).