### PR TITLE
Fix bundle vendor directory

### DIFF
--- a/roles/lobsters/tasks/main.yml
+++ b/roles/lobsters/tasks/main.yml
@@ -58,11 +58,11 @@
 - name: bundle install
   become: true
   become_user: lobsters
-  shell: bundle install --path http/vendor/bundle
+  shell: bundle install --path vendor/bundle
   register: bundler
   changed_when: "'Installing' in bundler or 'Updating' in bundler or 'upgrade' in bundler"
   args:
-    chdir: "/srv/lobste.rs/http"
+    chdir: "/srv/lobste.rs/http/"
 
 - name: migrate database
   when: clone.changed


### PR DESCRIPTION
Bundler's vendored gems were located at `/srv/lobste.rs/http/http/vendor/bundle` instead of `/srv/lobste.rs/http/vendor/bundle`. This PR fixes it. Carefull, because with the next install, it might reinstall the dependencies.
If you want to be sure, just previous ones are used: `mv -v /srv/lobste.rs/http/http/vendor/bundle/ /srv/lobste.rs/http/vendor/.`