### PR TITLE
Convert from cron to systemd timers

### DIFF
--- a/roles/lobsters/tasks/main.yml
+++ b/roles/lobsters/tasks/main.yml
@@ -113,14 +113,24 @@
     group=root
     mode='0755'
 
-- name: add crontab entry for maintenance job
+- name: add timer entry for maintenance job
   tags: cron
-  cron: >
-    state=present
-    name=lobsters-cron
-    user=lobsters
-    minute="*/5"
-    job=/usr/local/sbin/lobsters-cron
+  template: >
+    src="lobsters.timer.j2"
+    dest="/var/lib/systemd/timers/lobsters-cron.timer"
+    owner=root
+    group=root
+    mode='0755'
+  vars:
+    script_name: "/usr/local/sbin/lobsters-cron"
+    frequency: "15min"
+
+- name: enable timer for lobsters-cron
+  tags: cron
+  systemd:
+    name: lobsters-cron.timer
+    state: started
+    enabled: yes
 
 - name: cp daily job
   template: >
@@ -130,15 +140,25 @@
     group=root
     mode='0755'
 
-- name: add crontab entry for daily job
+- name: add timer entry for daily job
   tags: cron
-  cron: >
-    state=present
-    name=lobsters-daily
-    user=lobsters
-    minute="0"
-    hour="0"
-    job=/usr/local/sbin/lobsters-daily
+  template: >
+    src="lobsters.timer.j2"
+    dest="/var/lib/systemd/timers/lobsters-daily.timer"
+    owner=root
+    group=root
+    mode='0755'
+  vars:
+    script_name: "/usr/local/sbin/lobsters-daily"
+    frequency: "1d"
+
+- name: enable timer for lobsters-daily
+  tags: cron
+  systemd:
+    name: lobsters-daily.timer
+    state: started
+    enabled: yes
+
 
 - name: page expiration cron job
   tags: cron

--- a/roles/lobsters/templates/lobsters.timer.j2
+++ b/roles/lobsters/templates/lobsters.timer.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run {{ script_name }} every {{ frequency }}
+After=lobsters-unicorn.service
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec={{ frequency }}
+ExecStart={{ script_name }}
+EnvironmentFile=/srv/lobsters/environment
+
+[Install]
+WantedBy=timers.target

--- a/roles/unicorn/templates/lobsters-unicorn.service.j2
+++ b/roles/unicorn/templates/lobsters-unicorn.service.j2
@@ -23,6 +23,6 @@ ExecStart=/usr/local/bin/bundle exec "unicorn_rails -c config/unicorn.conf.rb -E
 ExecReload=/bin/kill -USR2 $MAINPID
 ExecStop=/bin/kill -QUIT $MAINPID
 
+EnvironmentFile=/srv/lobsters/environment
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
Supports [the elasticsearch](https://github.com/lobsters/lobsters/pull/579) pull request.

This allows us to pass all of the environment and configuration to the site via environment variables instead of having to hard code them in an initializer. 

Per @alanpost's request the deployment steps are as followed:

1. (Anytime) Make a `/srv/lobsters/environment` file following the [required format](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=). 
2. Merge in lobsters #579. 
3. Deploy lobsters #579 and leave elasticsearch disabled. This will keep things on the site from using it, but we can still index stories.
4. Start a rails console and run the following:
  * `ElasticSearch.client.indices.create(index: ElasticSearch.index)` To create the index.
  * `Story.find_each { |s| IndexStoryJob.perform_now(s) }` To index all of the submitted stories.
  * `Comment.find_each { |s| IndexCommentJob.perform_now(s) }` To index all of the submitted comments.
5. Enable elasticsearch in config/site.yml. 

Once that is completed, we should have all of the stories and comments searchable again. 

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
