### PR TITLE
roles/mockturtle: add a limit of 5min to the peterson trigger

### DIFF
--- a/roles/mockturtle/files/sopel_modules/peterson.py
+++ b/roles/mockturtle/files/sopel_modules/peterson.py
@@ -5,6 +5,7 @@ import sopel.bot as bot
 import sopel
 
 @sopel.module.rule(r'.*[Pp]eterson.*')
+@sopel.module.rate(channel=300)
 def peterson(bot, trigger):
     """Link to FAQ if Peterson is mentioned"""
     bot.reply("The site has nothing to do with Jordan Peterson: https://lobste.rs/about#michaelbolton")


### PR DESCRIPTION
The [sopel.module.rate](https://sopel.chat/docs/plugin.html#sopel.module.rate) let us limit the trigger on a per-user basis, channel or server.

Maybe channel is more useful, but I don't know. I've setted it for 5min per-user as suggested on by @alanpost here https://github.com/lobsters/lobsters-ansible/issues/51

Glad to contribute this small fix! Let me know if I missed something.