### PR TITLE
roles/lobsters: cron scripts honor maintenance.html.

### DIFF
--- a/roles/lobsters/templates/sbin/lobsters-cron.j2
+++ b/roles/lobsters/templates/sbin/lobsters-cron.j2
@@ -11,6 +11,11 @@ trap report ERR
 cd /srv/lobste.rs/http
 export RAILS_ENV={{ env }}
 
+if [ -f public/maintenance.html ];
+then
+  exit 0
+fi
+
 /usr/local/bin/bundle exec ruby script/sync_twitter_users
 /usr/local/bin/bundle exec ruby script/mail_new_activity.rb
 /usr/local/bin/bundle exec ruby script/post_to_twitter

--- a/roles/lobsters/templates/sbin/lobsters-daily.j2
+++ b/roles/lobsters/templates/sbin/lobsters-daily.j2
@@ -11,6 +11,11 @@ trap report ERR
 cd /srv/lobste.rs/http
 export RAILS_ENV={{ env }}
 
+if [ -f public/maintenance.html ];
+then
+  exit 0
+fi
+
 /usr/local/bin/bundle exec rake sitemap:refresh -s
 
 exit $err


### PR DESCRIPTION
Like nginx, the cron scripts should honor maintenance.html.
Abort without error if there is a maintenance window in
progress.
