### PR TITLE
pkgs: Add acl package

### DIFF
--- a/roles/lobsters/vars/main.yml
+++ b/roles/lobsters/vars/main.yml
@@ -13,3 +13,4 @@ required_packages:
   - ruby2.7
   - ruby2.7-dev
   - sqlite3
+  - acl


### PR DESCRIPTION
This adds the acl package, fixes issues when running file ops as
another user with become_user: lobsters

See issue: https://github.com/ansible/ansible/issues/74830

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
