### PR TITLE
Remove the now-unused fiill_flagged_cache script from cron

### DIFF
--- a/roles/lobsters/templates/sbin/lobsters-cron.j2
+++ b/roles/lobsters/templates/sbin/lobsters-cron.j2
@@ -16,7 +16,6 @@ then
   exit 0
 fi
 
-/srv/lobste.rs/.rbenv/shims/bundle exec ruby script/fill_flagged_cache.rb &
 /srv/lobste.rs/.rbenv/shims/bundle exec ruby script/mail_new_activity.rb &
 /srv/lobste.rs/.rbenv/shims/bundle exec ruby script/mastodon_post.rb &
 /srv/lobste.rs/.rbenv/shims/bundle exec ruby script/mastodon_sync_users.rb &


### PR DESCRIPTION
This is the sister PR to lobsters/lobsters#1586, completing part of lobsters/lobsters#1548. With the current PR structure, I suppose this would need to merge first to avoid breakage? Let me know if you'd prefer a different sequence and I'll reconfigure.