### PR TITLE
Remove the now-unused sitemap refresh job from daily cron

### DIFF
--- a/roles/lobsters/templates/sbin/lobsters-daily.j2
+++ b/roles/lobsters/templates/sbin/lobsters-daily.j2
@@ -16,8 +16,6 @@ then
   exit 0
 fi
 
-/srv/lobste.rs/.rbenv/shims/bundle exec rails sitemap:refresh -s
-
 find /srv/lobste.rs/http/tmp -type f -name 'rack%3A%3Aattack*' -mtime +2 -delete
 
 exit $err


### PR DESCRIPTION
Another for lobsters/lobsters#1548. Following its sister PR lobsters/lobsters#1605, this PR tidies up by removing the sitemap refresh from cron.