### PR TITLE
[#88] Add `Cache-Control` headers for Apple touch icons

### DIFF
--- a/roles/nginx/files/production/nginx/sites-available/lobste.rs
+++ b/roles/nginx/files/production/nginx/sites-available/lobste.rs
@@ -66,6 +66,14 @@ server {
     break;
   }
 
+  location ~ ^/(apple-touch-icon|touch-icon).*\.png$ {
+    include "snippets/abuse-*.conf"; # https://github.com/lobsters/lobsters/issues/761#issuecomment-2509149290
+
+    expires     max;
+    add_header  Cache-Control public;
+    break;
+  }
+
   # max upload size for avatars (the only upload the site takes now)
   client_max_body_size 2M;
 


### PR DESCRIPTION
This PR addresses issue lobsters/lobsters#1614 by updating the Nginx config with cache headers for Apple touch icons.